### PR TITLE
Changed import functions to be generators

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,11 +1,11 @@
 from settings import *
-from DataImport.gb_parse import parse_genbank_and_insert
+from DataImport.mongo_import import mongo_import_genbank
 from FindHGT.create_fasta import db_cds_to_fna
 
 
 def import_data():
 
-    parse_genbank_and_insert(INPUT, "test_collection")
+    mongo_import_genbank(INPUT, "collection")
 
 def run_blast():
 

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,6 @@
 # Once set up with user variables, change name to `user_settings.py`
+import pymongo
 
 INPUT = "/path/to/input/"
 OUTPUT = "/path/to/output/"
-MONGODB = "/path/to/db"
-
-MONGODB = "database_name"
+MONGODB = pymongo.MongoClient()["database_name"]

--- a/src/DataImport/gb_parse.py
+++ b/src/DataImport/gb_parse.py
@@ -1,108 +1,22 @@
 from Bio import SeqIO
 import os
 from re import search
-from DataImport.mongo_import import mongo_import_record
-
 
 
 def parse_genbank(genbank_file):
-    """
+    """ Generator yielding contig and gene records
+
     Retrieves data from a genbank file to prepare for import to MongoDB
     :param genbank_file: a file ending with ".gb" or ".gbk" that contains genomic information
-    :rtype list: list of gene records for insertion to MongoDB
+    :rtype generator[dict]: each iteration yields a record (dict) for insertion into MongoDB
     """
     with open(genbank_file, 'r') as in_handle:
         records = SeqIO.parse(in_handle, 'gb')
-        record_list = []
 
         # ToDo: Need a log file to record added locus_tags, species names etc, preferably with a way to reference back to original file
+        for record in add_contig_data(records):
+            yield record
 
-        record = add_contig_data(records)
-        record_list.append(record)
-
-    return record_list
-
-
-def parse_genbank_and_insert(genbank_file, collection):
-
-    with open(genbank_file, 'r') as in_handle:
-        records = SeqIO.parse(in_handle, 'gb')
-        record_list = []
-        contig_ids = []
-
-        contig_counter = 0
-        locus_tag_counter = 0
-
-        for contig in records:
-            contig_counter += 1
-            print contig_counter
-            try:
-                species = contig.annotations['source']
-            except KeyError:
-                # uses filename (without extension) as species name
-                species = os.path.splitext(os.path.basename(genbank_file)[0])
-
-            print species
-
-            if contig.id in contig_ids:
-                contig.id = "{}_{}".format(contig.id, contig_counter)
-            else:
-                contig_ids.append(contig.id)
-
-            mongo_import_record({
-                'type': 'contig',
-                'dna_seq': str(contig.seq),
-                'contig_id': contig.id,
-                'species': species
-                },
-                collection
-            )
-
-            for feature in contig.features:
-                locus_tag_counter += 1
-
-                try:
-                    aa_seq = feature.qualifiers['annotation'][0]
-                except KeyError:
-                    aa_seq = None
-
-                try:
-                    locus_tag = feature.qualifiers['locus_tag'][0]
-                except KeyError:
-                    locus_tag = 'kv_{}'.format(str(locus_tag_counter).zfill(5))
-
-                try:
-                    annotation = feature.qualifiers['product'][0]
-                except KeyError:
-                    annotation = None
-
-                feature_type = None
-                if feature.type == 'CDS':
-                    feature_type = 'CDS'
-                elif feature.type == 'rRNA':
-                    if check_16S(feature):
-                        feature_type = '16s'
-                    else:
-                        feature_type = 'rRNA'
-
-                # grabs DNA sequence from record object
-                dna_seq = str(feature.extract(contig).seq)
-
-                mongo_import_record({
-                    'type': feature_type,
-                    'dna_seq': dna_seq,
-                    'aa_seq': aa_seq,
-                    'locus_tag': locus_tag,
-                    'annotation': annotation,
-                    'location': {
-                        'start': int(feature.location.start),
-                        'end': int(feature.location.end),
-                        'strand': feature.location.strand,
-                        'contig': contig.id},
-                    'species':species
-                    },
-                    collection
-                )
 
 def check_16S(feature):
     """
@@ -129,31 +43,29 @@ def add_contig_data(records):
 
     for contig in records:
         contig_counter += 1
-        print contig_counter
         try:
             species = contig.annotations['source']
         except KeyError:
             # uses filename (without extension) as species name
             species = os.path.splitext(os.path.basename(genbank_file)[0])
 
-        print species
-
-        if contig.id in contig_ids:
+        if contig.id in contig_ids: # in case the id field is present but not unique
             contig.id = "{}_{}".format(contig.id, contig_counter)
         else:
             contig_ids.append(contig.id)
 
-        # todo: does it make sense to make a class for these record types? Ultimately we're just making a dict but...
-        record = {
+        # ToDo: append list of gene records contained within contig?
+        contig_record = {
             'type': 'contig',
             'dna_seq': str(contig.seq),
             'contig_id': contig.id,
             'species': species
         }
 
-        feature_record = add_features(contig)
+        yield contig_record
 
-        return record.update(feature_record)
+        for feature in add_features(contig):
+            yield feature
 
 def add_features(contig):
     locus_tag_counter = 0
@@ -200,4 +112,4 @@ def add_features(contig):
                 'contig': contig.id},
         }
 
-        return feature_record
+        yield feature_record

--- a/src/DataImport/gb_parse.py
+++ b/src/DataImport/gb_parse.py
@@ -96,6 +96,8 @@ def add_features(contig):
                 feature_type = '16s'
             else:
                 feature_type = 'rRNA'
+        else:
+            feature_type = feature.type
 
         # grabs DNA sequence from record object
         dna_seq = str(feature.extract(contig).seq)

--- a/src/DataImport/gb_parse.py
+++ b/src/DataImport/gb_parse.py
@@ -64,12 +64,11 @@ def add_contig_data(records):
 
         yield contig_record
 
-        for feature in add_features(contig):
+        for feature in add_features(contig, species):
             yield feature
 
-def add_features(contig):
+def add_features(contig, species):
     locus_tag_counter = 0
-
     for feature in contig.features:
         locus_tag_counter += 1
 
@@ -107,6 +106,7 @@ def add_features(contig):
             'aa_seq': aa_seq,
             'locus_tag': locus_tag,
             'annotation': annotation,
+            'species': species,
             'location': {
                 'start': int(feature.location.start),
                 'end': int(feature.location.end),

--- a/src/DataImport/mongo_import.py
+++ b/src/DataImport/mongo_import.py
@@ -1,25 +1,20 @@
-import pymongo
-from settings import MONGODB
+from settings import MONGODB as db
+from gb_parse import parse_genbank
 
-client = pymongo.MongoClient()
-db = client[MONGODB]
-
-
-def mongo_import_list(list_of_records, collection):
-    """
-    Takes a list of dicts and inserts them into MongoDB
-    :param list_of_records: list of dicts containing gene records
-    :param collection
-    """
-    for record in list_of_records:
-        db[collection].insert_one(record)
-
-    print db.collection_names(False)
 
 def mongo_import_record(record, collection):
-    """
-    Insert a single `record` into `collection`
+    """ Insert a single record (dict) into collection
+
     :param record: gene record
-    :param collection: MongoDB collection name
+    :param collection: Name of collection in MongoDB
     """
     db[collection].insert_one(record)
+
+def mongo_import_genbank(genbank_file, collection):
+    """ Parse genbank file and import into MongoDB
+
+    :param genbank_file: genbank file containing genomic information
+    :param collection:
+    """
+    for record in parse_genbank(genbank_file):
+        mongo_import_record(record, collection)


### PR DESCRIPTION
## Generator Change

There's a performance problem with loading all records into a list, and then importing all at once. For very large genbank files, it means holding gigabytes in memory. At the same time, having the parse functions responsible for mongo import seems impractical. 

With these changes, `mongo_import_genbank()` calls a generator function with 

``` python
for record in parse_genbank(genbank_file):
    mongo_import_record(record, collection)
```

The `parse_genbank()` function is a generator, that goes through a genbank file and `yield`s contig records and then gene records for each gene within a contig. This way, we're only holding one record at a time in memory. 
## Settings change

Dealing with the mongoDB commands has felt cumbersome. Also take a look at the change I made in `settings.py` - basically `MONGODB` becomes a reference to the database, so any time we need to do database operations we can do 

``` python
from settings import MONGODB as db
```

rather than

``` python
import pymongo

client = MongoClient()
db = client["database_name"]
```

We still need a better way to deal with the settings file though.
